### PR TITLE
parser: Implement the {un,}signed variants of llvm intrinsincs that r…

### DIFF
--- a/parser/parseBreaks.cpp
+++ b/parser/parseBreaks.cpp
@@ -217,7 +217,8 @@ void parseLoop(Func* func, const llvm::Loop *loop) {
                                                                  loop->getLoopLatch()->getTerminator()->getOperand(1)))
                                         );
     // add `goto afterDoWhileBlock;` expression right after the doWhile expr
-    loopPreheader->addExpr(createListOfOneGoto(loopPreheader, afterDoWhile));
+    //loopPreheader->addExpr(createListOfOneGoto(loopPreheader, afterDoWhile));
+    loopPreheader->addExpr(createListOfOneGoto(func->getBlock( loop->getLoopLatch() ), afterDoWhile));
 
     // nested loops are already parsed
     // parse yet unparsed blocks


### PR DESCRIPTION
…eturn the m{ax,in}imum of the two operands.

My idea comes from https://reviews.llvm.org/D9293?id=&download=true

The expression:

    call i8 @llvm.umin.i8(i8 %a, i8 %b)

is equivalent to

    %1 = icmp ult i8 %a, %b
    %2 = select i1 %1, i8 %a, i8 %b

This is what llvm2c outputs:

    a < b ? a : b