### PR TITLE
parser: decompiles 'sext i1 boolVal' as 'boolVal ? -1 : 0'

### DIFF
--- a/parser/createExpressions.cpp
+++ b/parser/createExpressions.cpp
@@ -998,10 +998,25 @@ static Expr* parseCastInstruction(const llvm::Instruction& ins, Program& program
 
     const llvm::CastInst* CI = llvm::cast<const llvm::CastInst>(&ins);
 
+
     if (llvm::isa<llvm::SExtInst>(CI)) {
         // for SExt, we do double cast -- first cast to the original
         // type that is made signed and then to the new type.
         // We must do that because we store all values as unsigned...
+    if (CI->getOperand(0)->getType()->isIntegerTy(1) &&
+        CI->getDestTy()->isIntegerTy() ) {
+        // create zero
+        auto zero = std::make_unique<Value>("0", program.getType(CI->getDestTy()));
+        // create -1
+        auto minusOne = std::make_unique<Value>("-1", program.getType(CI->getDestTy()));
+        // create comparison select ? -1 : 0
+        Expr* cond = program.getExpr(ins.getOperand(0));
+
+        auto slctExpr = program.makeExpr<SelectExpr>(cond, minusOne.get(), zero.get());
+        program.addOwnership(std::move(zero));
+        program.addOwnership(std::move(minusOne));
+        return slctExpr;
+    }
         auto *recastOrigExpr
             = program.makeExpr<CastExpr>(
                 expr,


### PR DESCRIPTION
https://llvm.org/docs/LangRef.html#sext-to-instruction

This is based on a fact that if you sext i1 cmp_result to i32, you can get either -1 or 0.